### PR TITLE
fix: Compatibility with PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
     "name": "mgid/phpmorphy",
-    "description": "phpMorphy - morphological analyzer library for Russisan, English languages.",
+    "description": "phpMorphy - morphological analyzer library for Russian, English, German and Ukrainian languages.",
     "keywords": [
         "phpMorphy"
     ],
     "homepage": "https://github.com/mgid/phpmorphy",
     "license": "MIT",
     "require": {
-        "php": ">=7.0"
+        "php": ">=7.4"
     },
     "autoload": {
         "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79b505d69798a66d04343d3f6e637672",
+    "content-hash": "33fbc839680e59d19b138c352bad01fc",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
@@ -13,7 +13,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0"
+        "php": ">=7.4"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
 }

--- a/libs/phpmorphy/src/morphiers.php
+++ b/libs/phpmorphy/src/morphiers.php
@@ -891,27 +891,27 @@ class phpMorphy_WordDescriptor_Collection implements Countable, IteratorAggregat
         return $result;
     }
     
-    function offsetExists($off) {
+    function offsetExists($off): bool {
         return isset($this->descriptors[$off]);
     }
     
-    function offsetUnset($off) {
+    function offsetUnset($off): void {
         throw new phpMorphy_Exception(__CLASS__ . " is not mutable");
     }
     
-    function offsetSet($off, $value) {
+    function offsetSet($off, $value): void {
         throw new phpMorphy_Exception(__CLASS__ . " is not mutable");
     }
     
-    function offsetGet($off) {
+    function offsetGet($off): mixed {
         return $this->getDescriptor($off);
     }
     
-    function count() {
+    function count(): int {
         return count($this->descriptors);
     }
     
-    function getIterator() {
+    function getIterator(): Traversable {
         return new ArrayIterator($this->descriptors);
     }
 }
@@ -1123,29 +1123,29 @@ class phpMorphy_WordDescriptor implements Countable, ArrayAccess, IteratorAggreg
 //        return count($result) ? $result : false;
     }
     
-    function count() {
+    function count(): int {
         return count($this->readAllForms());
     }
     
-    function offsetExists($off) {
+    function offsetExists($off): bool {
         $this->readAllForms();
         
         return isset($this->all_forms[$off]);
     }
     
-    function offsetSet($off, $value) {
+    function offsetSet($off, $value): void {
         throw new phpMorphy_Exception(__CLASS__ . " is not mutable");
     }
     
-    function offsetUnset($off) {
+    function offsetUnset($off): void {
         throw new phpMorphy_Exception(__CLASS__ . " is not mutable");
     }
     
-    function offsetGet($off) {
+    function offsetGet($off): mixed {
         return $this->getWordForm($off);
     }
     
-    function getIterator() {
+    function getIterator(): Traversable {
         $this->readAllForms();
         
         return new ArrayIterator($this->all_forms);


### PR DESCRIPTION
PHP 8.1: Return types in PHP built-in class methods and deprecation notices
https://php.watch/versions/8.1/internal-method-return-types